### PR TITLE
Add date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This task can receive the time to be set as a number(will be interpreted as a un
 
 In any case, it will fail if the date is not a second-exact date (i.e. has not zero milliseconds).
 
-String formats are thos supported by [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) but we recommend sticking to ISO string or YYYY-MM-DD(as the other depend on the timezone you are in and/or to implementation-specific date formats).
+String formats are those supported by [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) but we recommend sticking to ISO string or YYYY-MM-DD(as the other depend on the timezone you are in and/or to implementation-specific date formats).
 
 
 Examples: 
@@ -143,7 +143,7 @@ This task can receive the time to be set as a number(will be interpreted as a un
 
 In any case, it will fail if the date is not a second-exact date (i.e. has not zero milliseconds).
 
-String formats are thos supported by [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) but we recommend sticking to ISO string or YYYY-MM-DD(as the other depend on the timezone you are in and/or to implementation-specific date formats).
+String formats are those supported by [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) but we recommend sticking to ISO string or YYYY-MM-DD(as the other depend on the timezone you are in and/or to implementation-specific date formats).
 
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ setTimeNextBlock: set the timestamp of the next block(does not actually mine)
 For global options help run: hardhat help
 ```
 
+This task can receive the time to be set as a number(will be interpreted as a unix timestamp, in seconds), and a string in various formats. Its hreMethod counterpart can also receive a Date object.
+
+In any case, it will fail if the date is not a second-exact date (i.e. has not zero milliseconds).
+
+String formats are thos supported by [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) but we recommend sticking to ISO string or YYYY-MM-DD(as the other depend on the timezone you are in and/or to implementation-specific date formats).
+
+
+Examples: 
+
+- `hardhat setTimeNextBlock 2549333405`: Will set the time of the next block to Fri Oct 14 2050 04:10:05 GMT+0000
+- `hardhat setTimeNextBlock 2050-10-14`: Will set the time of the next block to Fri Oct 14 2050 00:00:00 GMT+0000
+- `hardhat setTimeNextBlock 2050-10-14T01:41:43+00:00`: Will set the time of the next block to Fri Oct 14 2050 01:41:43 GMT+0000
+
 ### setTime
 
 ```
@@ -125,6 +138,19 @@ setTime: mines a single block with a given time, effectively setting the time of
 
 For global options help run: hardhat help
 ```
+
+This task can receive the time to be set as a number(will be interpreted as a unix timestamp, in seconds), and a string in various formats. Its hreMethod counterpart can also receive a Date object.
+
+In any case, it will fail if the date is not a second-exact date (i.e. has not zero milliseconds).
+
+String formats are thos supported by [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) but we recommend sticking to ISO string or YYYY-MM-DD(as the other depend on the timezone you are in and/or to implementation-specific date formats).
+
+
+Examples:
+
+- `hardhat setTime 2549333405`: Will mint a block with the time set to Fri Oct 14 2050 04:10:05 GMT+0000
+- `hardhat setTime 2050-10-14`: Will mint a block with the time set to Fri Oct 14 2050 00:00:00 GMT+0000
+- `hardhat setTime 2050-10-14T01:41:43+00:00`: Will mint a block with the time set to Fri Oct 14 2050 01:41:43 GMT+0000
 
 
 ## Environment extensions
@@ -178,8 +204,3 @@ You can lint it using:
 or
 
 `npm run lint:fix`
-
-### Future work
-
-- Add `ms` to parse time deltas
-- Add some date parsing 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ task("setTime")
     "time",
     "timestamp of the next block",
     undefined,
-    types.int,
+    types.string,
     false
   )
   .setAction((args, hre) => hre.timeAndMine.setTime(args.time));
@@ -57,7 +57,7 @@ task("setTimeNextBlock")
     "time",
     "timestamp of the next block",
     undefined,
-    types.int,
+    types.string,
     false
   )
   .setAction((args, hre) => hre.timeAndMine.setTimeNextBlock(args.time));

--- a/src/param-parsing.ts
+++ b/src/param-parsing.ts
@@ -1,5 +1,19 @@
 import ms from "ms";
 
+import { Dateish } from "./type-extensions";
+
+function isDate(date: Dateish): date is Date {
+  return date instanceof Date;
+}
+
+function isTimestamp(date: Dateish): date is number {
+  return typeof date === "number";
+}
+
+function isString(date: Dateish): date is string {
+  return typeof date === "string";
+}
+
 export const parseDelta = (delta: string) => {
   const deltaInSeconds = Number.isNaN(Number(delta))
     ? ms(delta) / 1000
@@ -9,4 +23,26 @@ export const parseDelta = (delta: string) => {
   if (deltaInSeconds < 0)
     throw new Error("cannot be called with a negative value");
   return deltaInSeconds;
+};
+
+const convertToTimestamp = (date: Dateish): number => {
+  if (isDate(date)) {
+    return Number(date) / 1000;
+  } else if (isString(date)) {
+    return Number.isNaN(Number(date))
+      ? Number(Date.parse(date)) / 1000
+      : Number(date);
+  } else if (isTimestamp(date)) {
+    return date;
+  }
+  throw new Error("type not supported");
+};
+
+export const parseDate = (date: Dateish): number => {
+  const timestamp = convertToTimestamp(date);
+
+  if (!Number.isInteger(timestamp))
+    throw new Error("cannot be called with a non integer value");
+  if (timestamp < 0) throw new Error("cannot be called with a negative value");
+  return timestamp;
 };

--- a/src/time-and-mine.ts
+++ b/src/time-and-mine.ts
@@ -1,7 +1,8 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getLastBlock } from "./helpers";
-import { parseDelta } from "./param-parsing";
+import { parseDate, parseDelta } from "./param-parsing";
+import { Dateish } from "./type-extensions";
 
 const mineOneBlock = async (hre: HardhatRuntimeEnvironment) =>
   hre.network.provider.send("evm_mine", []);
@@ -36,12 +37,12 @@ const setTimeIncrease =
     await setTimeNextBlock(hre)(nextTimestamp);
   };
 
-const setTime = (hre: HardhatRuntimeEnvironment) => (time: number) =>
-  hre.network.provider.send("evm_mine", [time]) as Promise<void>;
+const setTime = (hre: HardhatRuntimeEnvironment) => (date: Dateish) =>
+  hre.network.provider.send("evm_mine", [parseDate(date)]) as Promise<void>;
 
-const setTimeNextBlock = (hre: HardhatRuntimeEnvironment) => (time: number) =>
+const setTimeNextBlock = (hre: HardhatRuntimeEnvironment) => (date: Dateish) =>
   hre.network.provider.send("evm_setNextBlockTimestamp", [
-    time,
+    parseDate(date),
   ]) as Promise<void>;
 
 export default (
@@ -50,8 +51,8 @@ export default (
   increaseTime: (delta: string) => Promise<void>;
   setTimeIncrease: (delta: string) => Promise<void>;
   mine: (amount: number) => Promise<void>;
-  setTime: (time: number) => Promise<void>;
-  setTimeNextBlock: (time: number) => Promise<void>;
+  setTime: (time: Dateish) => Promise<void>;
+  setTimeNextBlock: (time: Dateish) => Promise<void>;
 } => ({
   increaseTime: increaseTime(hre),
   setTimeIncrease: setTimeIncrease(hre),

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -2,6 +2,8 @@ import "hardhat/types/runtime";
 
 import "./time-and-mine";
 
+export type Dateish = string | number | Date;
+
 declare module "hardhat/types/runtime" {
   // This is an example of an extension to the Hardhat Runtime Environment.
   // This new field will be available in tasks' actions, scripts, and tests.
@@ -10,8 +12,8 @@ declare module "hardhat/types/runtime" {
       increaseTime: (delta: string) => Promise<void>;
       setTimeIncrease: (delta: string) => Promise<void>;
       mine: (amount: number) => Promise<void>;
-      setTime: (time: number) => Promise<void>;
-      setTimeNextBlock: (time: number) => Promise<void>;
+      setTime: (time: Dateish) => Promise<void>;
+      setTimeNextBlock: (time: Dateish) => Promise<void>;
     };
   }
 }

--- a/test/hreMethods/setTime.test.ts
+++ b/test/hreMethods/setTime.test.ts
@@ -1,36 +1,105 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { expect } from "chai";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getLastBlock } from "../../src/helpers";
+import { Dateish } from "../type-extensions";
 
 import { useEnvironment } from "./helpers";
+
+async function checkSetTime(
+  hre: HardhatRuntimeEnvironment,
+  numberToTime: (timestamp: number) => Dateish,
+  delta: number
+) {
+  const startBlock = await getLastBlock(hre);
+
+  const startTime = parseInt(startBlock.timestamp, 16);
+  const targetTime = startTime + delta;
+  await hre.timeAndMine.setTime(numberToTime(targetTime));
+  const endBlock = await getLastBlock(hre);
+
+  expect(parseInt(startBlock.number, 16) + 1).to.equal(
+    parseInt(endBlock.number, 16)
+  );
+  return expect(parseInt(endBlock.timestamp, 16)).to.equal(targetTime);
+}
 
 describe("setTime tests", function () {
   describe("Hardhat Runtime Environment extension", function () {
     useEnvironment("hardhat-project");
 
-    function checkSetTime(date: number) {
-      it("mines a block and sets the exact time", async function () {
-        const startBlock = await getLastBlock(this.hre);
-        await this.hre.timeAndMine.setTime(date);
-        const endBlock = await getLastBlock(this.hre);
+    function checkSetTimeMultipleFormats(delta: number) {
+      it("mines a block and sets the exact time using a number", async function () {
+        return checkSetTime(this.hre, (timestamp: number) => timestamp, delta);
+      });
 
-        expect(parseInt(startBlock.number, 16) + 1).to.equal(
-          parseInt(endBlock.number, 16)
+      it("mines a block and sets the exact time using a string date", async function () {
+        return checkSetTime(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000).toISOString(),
+          delta
         );
-        return expect(parseInt(endBlock.timestamp, 16)).to.equal(date);
+      });
+
+      it("mines a block and sets the exact time using a Date", async function () {
+        return checkSetTime(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000),
+          delta
+        );
       });
     }
 
-    checkSetTime(new Date().getTime());
-    checkSetTime(new Date().getTime() + 10);
-    checkSetTime(new Date().getTime() + 1000);
-    checkSetTime(new Date().getTime() + 10000);
+    checkSetTimeMultipleFormats(1);
+    checkSetTimeMultipleFormats(10);
+    checkSetTimeMultipleFormats(1000);
+    checkSetTimeMultipleFormats(10000);
+
+    it("mines a block and sets the exact time using utc string", async function () {
+      return checkSetTime(
+        this.hre,
+        (timestamp: number) => new Date(timestamp * 1000).toUTCString(),
+        1
+      );
+    });
+
+    it("mines a block and sets the exact time using a YYYY-MM-DD format", async function () {
+      const startBlock = await getLastBlock(this.hre);
+
+      await this.hre.timeAndMine.setTime("2050-10-14");
+      const endBlock = await getLastBlock(this.hre);
+
+      expect(parseInt(startBlock.number, 16) + 1).to.equal(
+        parseInt(endBlock.number, 16)
+      );
+      return expect(parseInt(endBlock.timestamp, 16)).to.equal(2549318400); // Taken from online conversion tool
+    });
 
     it("fails if called with a passed date", async function () {
       const latestBlock = await getLastBlock(this.hre);
       const nextTimestamp = parseInt(latestBlock.timestamp, 16) - 1;
-      return expect(this.hre.timeAndMine.setTime(nextTimestamp)).to.be.rejected;
+      return expect(
+        this.hre.timeAndMine.setTime(nextTimestamp)
+      ).to.be.rejectedWith(" is lower than previous block's timestamp ");
+    });
+
+    it("fails if called with a passed date as a string", async function () {
+      const latestBlock = await getLastBlock(this.hre);
+      const nextTimestamp = Math.floor(parseInt(latestBlock.timestamp, 16)) - 1;
+      return expect(
+        this.hre.timeAndMine.setTime(
+          new Date(nextTimestamp * 1000).toISOString()
+        )
+      ).to.be.rejectedWith(" is lower than previous block's timestamp ");
+    });
+
+    it("fails if called with a passed date as a Date", async function () {
+      const latestBlock = await getLastBlock(this.hre);
+      const nextTimestamp = Math.floor(parseInt(latestBlock.timestamp, 16)) - 1;
+      return expect(
+        this.hre.timeAndMine.setTime(new Date(nextTimestamp * 1000))
+      ).to.be.rejectedWith(" is lower than previous block's timestamp ");
     });
   });
 });

--- a/test/hreMethods/setTimeNextBlock.test.ts
+++ b/test/hreMethods/setTimeNextBlock.test.ts
@@ -1,37 +1,70 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { expect } from "chai";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getLastBlock } from "../../src/helpers";
+import { Dateish } from "../type-extensions";
 
 import { useEnvironment } from "./helpers";
+
+async function checkSetTimeNextBlock(
+  hre: HardhatRuntimeEnvironment,
+  numberToTime: (timestamp: number) => Dateish,
+  delta: number
+) {
+  const startBlock = await getLastBlock(hre);
+  const startTime = parseInt(startBlock.timestamp, 16);
+  const targetTime = startTime + delta;
+
+  await hre.timeAndMine.setTimeNextBlock(numberToTime(targetTime));
+  const intermmediateBlock = await getLastBlock(hre);
+
+  expect(parseInt(startBlock.number, 16)).to.equal(
+    parseInt(intermmediateBlock.number, 16)
+  );
+  await hre.timeAndMine.mine(1);
+  const endBlock = await getLastBlock(hre);
+
+  expect(parseInt(startBlock.number, 16) + 1).to.equal(
+    parseInt(endBlock.number, 16)
+  );
+  return expect(parseInt(endBlock.timestamp, 16)).to.equal(targetTime);
+}
 
 describe("setTimeNextBlock tests", function () {
   describe("Hardhat Runtime Environment extension", function () {
     useEnvironment("hardhat-project");
 
-    function checkSetTimeNextBlock(date: number) {
-      it("DOES NOT mine a block and sets the exact time for the next block", async function () {
-        const startBlock = await getLastBlock(this.hre);
-        await this.hre.timeAndMine.setTimeNextBlock(date);
-        const intermmediateBlock = await getLastBlock(this.hre);
-
-        expect(parseInt(startBlock.number, 16)).to.equal(
-          parseInt(intermmediateBlock.number, 16)
+    function checkSetTimeNextBlockMultipleFormats(delta: number) {
+      it("DOES NOT mine a block and sets the exact time for the next block using a number", async function () {
+        return checkSetTimeNextBlock(
+          this.hre,
+          (timestamp: number) => timestamp,
+          delta
         );
-        await this.hre.timeAndMine.mine(1);
-        const endBlock = await getLastBlock(this.hre);
+      });
 
-        expect(parseInt(startBlock.number, 16) + 1).to.equal(
-          parseInt(endBlock.number, 16)
+      it("DOES NOT mine a block and sets the exact time for the next block using a string date", async function () {
+        return checkSetTimeNextBlock(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000).toISOString(),
+          delta
         );
-        return expect(parseInt(endBlock.timestamp, 16)).to.equal(date);
+      });
+
+      it("DOES NOT mine a block and sets the exact time for the next block using a Date", async function () {
+        return checkSetTimeNextBlock(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000),
+          delta
+        );
       });
     }
 
-    checkSetTimeNextBlock(new Date().getTime());
-    checkSetTimeNextBlock(new Date().getTime() + 10);
-    checkSetTimeNextBlock(new Date().getTime() + 1000);
-    checkSetTimeNextBlock(new Date().getTime() + 10000);
+    checkSetTimeNextBlockMultipleFormats(1);
+    checkSetTimeNextBlockMultipleFormats(10);
+    checkSetTimeNextBlockMultipleFormats(1000);
+    checkSetTimeNextBlockMultipleFormats(10000);
 
     it("fails if called with a passed date", async function () {
       const latestBlock = await getLastBlock(this.hre);

--- a/test/tasks/helpers.ts
+++ b/test/tasks/helpers.ts
@@ -3,6 +3,8 @@ import { resetHardhatContext } from "hardhat/plugins-testing";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import path from "path";
 
+import { Dateish } from "../type-extensions";
+
 declare module "mocha" {
   interface Context {
     hre: HardhatRuntimeEnvironment;
@@ -31,10 +33,11 @@ const setTimeIncrease = (delta: string) =>
 
 const mine = (amount: number) => executeTask("mine", `--amount ${amount}`);
 
-const setTime = (time: number) => executeTask("setTime", time.toString());
+const setTime = (time: Dateish) =>
+  executeTask("setTime", '"' + time.toString() + '"');
 
-const setTimeNextBlock = (time: number) =>
-  executeTask("setTimeNextBlock", time.toString());
+const setTimeNextBlock = (time: Dateish) =>
+  executeTask("setTimeNextBlock", '"' + time.toString() + '"');
 
 const useEnvironment = (fixtureProjectName: string) => {
   beforeEach("Loading hardhat environment", function () {

--- a/test/tasks/setTime.test.ts
+++ b/test/tasks/setTime.test.ts
@@ -1,33 +1,61 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { expect } from "chai";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getLastBlock } from "../../src/helpers";
+import { Dateish } from "../type-extensions";
 
 import tasksHelper from "./helpers";
 
-describe("setTime task tests", function () {
+async function checkSetTime(
+  hre: HardhatRuntimeEnvironment,
+  numberToTime: (timestamp: number) => Dateish,
+  delta: number
+) {
+  const startBlock = await getLastBlock(hre);
+  const setDate = parseInt(startBlock.timestamp, 16) + delta;
+  await tasksHelper.setTime(numberToTime(setDate));
+  const endBlock = await getLastBlock(hre);
+
+  expect(parseInt(startBlock.number, 16) + 1).to.equal(
+    parseInt(endBlock.number, 16)
+  );
+
+  return expect(parseInt(endBlock.timestamp, 16)).to.equal(setDate);
+}
+
+describe.only("setTime task tests", function () {
   describe("Hardhat Runtime Environment extension", function () {
     tasksHelper.useEnvironment("hardhat-project");
     // We need to receive difference because we do not know the current date, and that could be problematic
     // We do the sum IN the test
-    function checkSetTime(difference: number) {
-      it("mines a block and sets the exact time", async function () {
-        const startBlock = await getLastBlock(this.hre);
-        const setDate = parseInt(startBlock.timestamp, 16) + difference;
-        await tasksHelper.setTime(setDate);
-        const endBlock = await getLastBlock(this.hre);
 
-        expect(parseInt(startBlock.number, 16) + 1).to.equal(
-          parseInt(endBlock.number, 16)
+    function checkSetTimeMultipleFormats(delta: number) {
+      it("mines a block and sets the exact time using a number", async function () {
+        return checkSetTime(this.hre, (timestamp: number) => timestamp, delta);
+      });
+
+      it("mines a block and sets the exact time using a string date", async function () {
+        return checkSetTime(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000).toISOString(),
+          delta
         );
-        return expect(parseInt(endBlock.timestamp, 16)).to.equal(setDate);
+      });
+
+      it("mines a block and sets the exact time using a Date", async function () {
+        return checkSetTime(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000),
+          delta
+        );
       });
     }
 
-    checkSetTime(1);
-    checkSetTime(10);
-    checkSetTime(1000);
-    checkSetTime(10000);
+    checkSetTimeMultipleFormats(1);
+    checkSetTimeMultipleFormats(10);
+    checkSetTimeMultipleFormats(1000);
+    checkSetTimeMultipleFormats(10000);
 
     it("fails if called with a passed date", async function () {
       const latestBlock = await getLastBlock(this.hre);

--- a/test/tasks/setTimeNextBlock.test.ts
+++ b/test/tasks/setTimeNextBlock.test.ts
@@ -1,39 +1,70 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { expect } from "chai";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getLastBlock } from "../../src/helpers";
+import { Dateish } from "../type-extensions";
 
 import tasksHelper from "./helpers";
+
+async function checkSetTimeNextBlock(
+  hre: HardhatRuntimeEnvironment,
+  numberToTime: (timestamp: number) => Dateish,
+  delta: number
+) {
+  const startBlock = await getLastBlock(hre);
+  const setDate = parseInt(startBlock.timestamp, 16) + delta;
+  await tasksHelper.setTimeNextBlock(numberToTime(setDate));
+  const intermmediateBlock = await getLastBlock(hre);
+
+  expect(parseInt(startBlock.number, 16)).to.equal(
+    parseInt(intermmediateBlock.number, 16)
+  );
+  await tasksHelper.mine(1);
+  const endBlock = await getLastBlock(hre);
+
+  expect(parseInt(startBlock.number, 16) + 1).to.equal(
+    parseInt(endBlock.number, 16)
+  );
+  return expect(parseInt(endBlock.timestamp, 16)).to.equal(setDate);
+}
 
 describe("setTimeNextBlock task tests", function () {
   describe("Hardhat Runtime Environment extension", function () {
     tasksHelper.useEnvironment("hardhat-project");
     // We need to receive difference because we do not know the current date, and that could be problematic
     // We do the sum IN the test
-    function checkSetTimeNextBlock(difference: number) {
-      it("DOES NOT mine a block and sets the exact time for the next block", async function () {
-        const startBlock = await getLastBlock(this.hre);
-        const setDate = parseInt(startBlock.timestamp, 16) + difference;
-        await tasksHelper.setTimeNextBlock(setDate);
-        const intermmediateBlock = await getLastBlock(this.hre);
 
-        expect(parseInt(startBlock.number, 16)).to.equal(
-          parseInt(intermmediateBlock.number, 16)
+    function checkSetTimeNextMultipleFormats(delta: number) {
+      it("DOES NOT mine a block and sets the exact time for the next block using a number", async function () {
+        return checkSetTimeNextBlock(
+          this.hre,
+          (timestamp: number) => timestamp,
+          delta
         );
-        await tasksHelper.mine(1);
-        const endBlock = await getLastBlock(this.hre);
+      });
 
-        expect(parseInt(startBlock.number, 16) + 1).to.equal(
-          parseInt(endBlock.number, 16)
+      it("DOES NOT mine a block and sets the exact time for the next block using a string date", async function () {
+        return checkSetTimeNextBlock(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000).toISOString(),
+          delta
         );
-        return expect(parseInt(endBlock.timestamp, 16)).to.equal(setDate);
+      });
+
+      it("DOES NOT mine a block and sets the exact time for the next block using a Date", async function () {
+        return checkSetTimeNextBlock(
+          this.hre,
+          (timestamp: number) => new Date(timestamp * 1000),
+          delta
+        );
       });
     }
 
-    checkSetTimeNextBlock(1);
-    checkSetTimeNextBlock(10);
-    checkSetTimeNextBlock(1000);
-    checkSetTimeNextBlock(10000);
+    checkSetTimeNextMultipleFormats(1);
+    checkSetTimeNextMultipleFormats(10);
+    checkSetTimeNextMultipleFormats(1000);
+    checkSetTimeNextMultipleFormats(10000);
 
     it("fails if called with a passed date", async function () {
       const latestBlock = await getLastBlock(this.hre);


### PR DESCRIPTION
## Description
Add date parsing so that setTime and setTimeNextBlock now support Date objects, strings and numbers(timestamps).

## Motivation and Context

To improve DevX, I added date parsing to methods that previously received only timestamps.

This will allow developers that have to use specific dates to be more clear on their intentions.

Also, the Date object support will allow devs to directly send their programatically modified dates without worrying on the format,




## How Has This Been Tested?

Automated integration tests have been made

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


